### PR TITLE
Fix Google Play Store deployment pipeline error

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -91,4 +91,3 @@ jobs:
         releaseFiles: build/app/outputs/bundle/release/app-release.aab
         track: alpha
         status: completed
-        changesNotSentForReview: true


### PR DESCRIPTION
Remove changesNotSentForReview parameter from upload-google-play action as Google Play Store API no longer supports this parameter - changes are automatically sent for review.

Fixes deployment error: "Changes are sent for review automatically. The query parameter changesNotSentForReview must not be set."

🤖 Generated with [Claude Code](https://claude.ai/code)